### PR TITLE
Remove "Support" Section from Readme, since that channel is no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,7 +699,3 @@ _Note: Some legacy behavior and options were removed from `fbtee`. If you have a
 - `fbt` was originally created by [Facebook](https://github.com/facebook/fbt).
 - The auto-import plugin was created by [@alexandernanberg](https://github.com/alexandernanberg).
 - [Nakazawa Tech](https://nkzw.tech) rewrote `fbt` into `fbtee` and continues to maintain this project.
-
-## Support
-
-- Check out the [#fbtee channel on Reactiflux's Discord server](https://discord.gg/reactiflux).


### PR DESCRIPTION
The fbtee team members have stopped supporting that channel and left the Reactiflux discord. That channel has been archived as a result. I'm removing the "Support" section since it is no longer accurate.