### PR TITLE
Collect - skip directories with extension in name

### DIFF
--- a/packages/babel-plugin-fbtee/src/bin/__tests__/manifest-test.tsx
+++ b/packages/babel-plugin-fbtee/src/bin/__tests__/manifest-test.tsx
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { generateManifest } from '../manifestUtils.tsx';
 
@@ -16,9 +17,12 @@ describe('manifest', () => {
 
   it('should skip directories whose names match the file extension glob', async () => {
     const srcPath = join(import.meta.dirname, '../__fixtures__');
+    const DIRNAME = 'dir-with-js-extension.js';
+    // ensure the fixture directory exists (otherwise test will pass even if fixture was renamed/removed)
+    expect(existsSync(join(srcPath, DIRNAME))).toBe(true);
 
     const { files } = await generateManifest([srcPath], srcPath);
 
-    expect(files).not.toContain('dir-with-js-extension.js');
+    expect(files).not.toContain(DIRNAME);
   });
 });

--- a/packages/babel-plugin-fbtee/src/bin/__tests__/manifest-test.tsx
+++ b/packages/babel-plugin-fbtee/src/bin/__tests__/manifest-test.tsx
@@ -13,4 +13,12 @@ describe('manifest', () => {
     expect(JSON.stringify(files, null, 2)).toMatchSnapshot();
     expect(JSON.stringify(enumManifest, null, 2)).toMatchSnapshot();
   });
+
+  it('should skip directories whose names match the file extension glob', async () => {
+    const srcPath = join(import.meta.dirname, '../__fixtures__');
+
+    const { files } = await generateManifest([srcPath], srcPath);
+
+    expect(files).not.toContain('dir-with-js-extension.js');
+  });
 });

--- a/packages/babel-plugin-fbtee/src/bin/manifestUtils.tsx
+++ b/packages/babel-plugin-fbtee/src/bin/manifestUtils.tsx
@@ -41,6 +41,7 @@ export async function generateManifest(
         ? globSync(resolve(cwd, src) + '/**/*' + extensions)
         : [src],
     )
+    .filter((filepath) => statSync(filepath).isFile())
     .filter((filepath) =>
       ModuleNameRegExp.test(fs.readFileSync(filepath, 'utf8')),
     )


### PR DESCRIPTION
Filter out directories (with odd names like `directory-name-with-ext.ts`) in `generateManifest` function.
Without it, `fbtee collect` script fails with `Error: EISDIR: illegal operation on a directory, read` since path to directory was passed to `fs.readFileSync(filepath, 'utf8')`

You may ask, who would name a directory like this - Vitest does generate directories for screenshots of failed tests with name matching the spec file.