### PR TITLE
fix: allow whitespace character when configuring ignoreWords

### DIFF
--- a/packages/eslint-plugin-fbtee/src/__tests__/no-untranslated-strings-test.tsx
+++ b/packages/eslint-plugin-fbtee/src/__tests__/no-untranslated-strings-test.tsx
@@ -249,6 +249,26 @@ ruleTester.run('no-untranslated-strings', rule, {
     },
     {
       code: `
+        <input placeholder=" " />
+       `,
+      options: [
+        {
+          ignoredWords: [' '],
+        },
+      ],
+    },
+    {
+      code: `
+        <span>{' '}</span>
+       `,
+      options: [
+        {
+          ignoredWords: [' '],
+        },
+      ],
+    },
+    {
+      code: `
         <textarea rows={2}></textarea>
        `,
     },

--- a/packages/eslint-plugin-fbtee/src/rules/no-untranslated-strings.tsx
+++ b/packages/eslint-plugin-fbtee/src/rules/no-untranslated-strings.tsx
@@ -32,7 +32,7 @@ const shouldIgnoreParent = (node: TSESTree.Node) => {
 export default createRule<Options, 'unwrappedString'>({
   create(context, options) {
     const ignoredWords = new Set(
-      options[0].ignoredWords.map((value) => value.trim().toLowerCase()),
+      options[0].ignoredWords.map((value) => value.toLowerCase()),
     );
 
     const isIgnoredWord = (value: string) =>


### PR DESCRIPTION
Currently its not possible to add whitespace character to ignoredWords option in plugin configuration.

Consider a project with eslint plugin enabled and an example component that uses `{" "}` in JSX to achieve a gap.

ESLint config:
```
{
  ...
  rules: {
      ...fbtee.configs.strict.rules,
      '@nkzw/fbtee/no-untranslated-strings': [
        'error',
        { ignoredWords: [' '] },
      ],
  },
}
```

Example component:
```
export const MyComponent = () => (
  <div>
    <fbt desc="my component - text" project="common">
      My EN text
    </fbt>{" "} // fbtee eslint plugin will raise an error here
    <div>
      <button>...</button>
    </div>
  </div>
);
```

Looks like the `trim` that was removed in this PR is used only to parse the input `ignoredWords` which might be an exaggeration.
What's ur opinion on that? If you don't agree, maybe just an additional check specific for whitespace character should be added here 🤔 