### PR TITLE
feat: fbtee prepare-translations - add option to sort translation JSONs by hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ After marking your strings for translation with `<fbt>`, run the following comma
 pnpm fbtee collect
 ```
 
-You can now upload the `source_strings.json` file to your translation provider, for example [Crowdin](https://crowdin.com/). If you'd like to manually edit the strings, you can use the `fbtee prepare-translations --locales de_DE` to generate a JSON file that can be edited directly.
+You can now upload the `source_strings.json` file to your translation provider, for example [Crowdin](https://crowdin.com/). If you'd like to manually edit the strings, you can use the `fbtee prepare-translations --locales de_DE` to generate a JSON file that can be edited directly. Pass `--sort-by-hash` to keep entries in a deterministic order for cleaner diffs when the file is committed.
 
 #### Generated File Structure
 

--- a/packages/babel-plugin-fbtee/src/bin/__tests__/prepareTranslations-test.tsx
+++ b/packages/babel-plugin-fbtee/src/bin/__tests__/prepareTranslations-test.tsx
@@ -1,0 +1,139 @@
+/* eslint-disable perfectionist/sort-objects */
+import { describe, expect, it } from '@jest/globals';
+import type { HashToLeaf } from '../FbtCollector.tsx';
+import { updateTranslations } from '../prepareTranslationsUtils.tsx';
+import type { Translations } from '../translateUtils.tsx';
+
+const phrase = (desc: string, text: string) => ({ desc, text });
+
+const existingEntry = (translation: string, description = 'desc') => ({
+  description,
+  status: 'translated',
+  tokens: [],
+  translations: [{ translation, variations: {} }],
+  types: [],
+});
+
+describe('updateTranslations', () => {
+  describe('without sortByHash (default)', () => {
+    it('preserves pre-existing order and appends new hashes at the end', () => {
+      const phrases: HashToLeaf = {
+        zzz: phrase('z desc', 'z text'),
+        aaa: phrase('a desc', 'a text'),
+        mmm: phrase('m desc', 'm text'),
+        newOne: phrase('new desc', 'new text'),
+      };
+      const translations: Translations = {
+        zzz: existingEntry('Z translated'),
+        aaa: existingEntry('A translated'),
+        mmm: existingEntry('M translated'),
+      };
+
+      const result = updateTranslations(phrases, translations);
+
+      expect(Object.keys(result)).toEqual(['zzz', 'aaa', 'mmm', 'newOne']);
+      expect(result.zzz?.translations[0].translation).toBe('Z translated');
+      expect(result.newOne?.status).toBe('new');
+    });
+  });
+
+  describe('with sortByHash=true', () => {
+    it('sorts pre-existing entries by hash and preserves translation values', () => {
+      const phrases: HashToLeaf = {
+        zzz: phrase('z desc', 'z text'),
+        aaa: phrase('a desc', 'a text'),
+        mmm: phrase('m desc', 'm text'),
+      };
+      const translations: Translations = {
+        zzz: existingEntry('Z translated'),
+        aaa: existingEntry('A translated'),
+        mmm: existingEntry('M translated'),
+      };
+
+      const result = updateTranslations(phrases, translations, true);
+
+      expect(Object.keys(result)).toEqual(['aaa', 'mmm', 'zzz']);
+      expect(result.aaa?.translations[0].translation).toBe('A translated');
+      expect(result.mmm?.translations[0].translation).toBe('M translated');
+      expect(result.zzz?.translations[0].translation).toBe('Z translated');
+    });
+
+    it('sorts mixed existing + new entries and drops removed ones', () => {
+      const phrases: HashToLeaf = {
+        keep2: phrase('keep2 desc', 'keep2 text'),
+        new1: phrase('new1 desc', 'new1 text'),
+        keep1: phrase('keep1 desc', 'keep1 text'),
+        new2: phrase('new2 desc', 'new2 text'),
+      };
+      const translations: Translations = {
+        keep1: existingEntry('keep1 translated'),
+        remove1: existingEntry('remove1 translated'),
+        keep2: existingEntry('keep2 translated'),
+      };
+
+      const result = updateTranslations(phrases, translations, true);
+
+      expect(Object.keys(result)).toEqual(['keep1', 'keep2', 'new1', 'new2']);
+      expect(result.remove1).toBeUndefined();
+      expect(result.keep1?.translations[0].translation).toBe(
+        'keep1 translated',
+      );
+      expect(result.keep2?.translations[0].translation).toBe(
+        'keep2 translated',
+      );
+      expect(result.new1?.status).toBe('new');
+      expect(result.new1?.translations[0].translation).toBe('new1 text');
+      expect(result.new2?.status).toBe('new');
+    });
+
+    it('sorts when there are no pre-existing translations', () => {
+      const phrases: HashToLeaf = {
+        zzz: phrase('z desc', 'z text'),
+        aaa: phrase('a desc', 'a text'),
+        mmm: phrase('m desc', 'm text'),
+      };
+
+      const result = updateTranslations(phrases, {}, true);
+
+      expect(Object.keys(result)).toEqual(['aaa', 'mmm', 'zzz']);
+    });
+
+    it('returns an empty object when all pre-existing entries are removed', () => {
+      const translations: Translations = {
+        gone1: existingEntry('gone1 translated'),
+        gone2: existingEntry('gone2 translated'),
+      };
+
+      const result = updateTranslations({}, translations, true);
+
+      expect(result).toEqual({});
+    });
+
+    it('produces deterministic output regardless of input insertion order', () => {
+      const phrasesA: HashToLeaf = {
+        zzz: phrase('z desc', 'z text'),
+        aaa: phrase('a desc', 'a text'),
+        mmm: phrase('m desc', 'm text'),
+      };
+      const phrasesB: HashToLeaf = {
+        mmm: phrase('m desc', 'm text'),
+        zzz: phrase('z desc', 'z text'),
+        aaa: phrase('a desc', 'a text'),
+      };
+      const translationsA: Translations = {
+        zzz: existingEntry('Z translated'),
+        aaa: existingEntry('A translated'),
+      };
+      const translationsB: Translations = {
+        aaa: existingEntry('A translated'),
+        zzz: existingEntry('Z translated'),
+      };
+
+      const resultA = updateTranslations(phrasesA, translationsA, true);
+      const resultB = updateTranslations(phrasesB, translationsB, true);
+
+      expect(Object.keys(resultA)).toEqual(Object.keys(resultB));
+      expect(resultA).toEqual(resultB);
+    });
+  });
+});

--- a/packages/babel-plugin-fbtee/src/bin/prepare-translations.tsx
+++ b/packages/babel-plugin-fbtee/src/bin/prepare-translations.tsx
@@ -1,11 +1,10 @@
 import { existsSync, globSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import yargs from 'yargs';
-import { SerializedTranslationData } from '../translate/TranslationData.tsx';
-import { PatternString } from '../Types.ts';
 import { CollectFbtOutput } from './collect.tsx';
 import { HashToLeaf } from './FbtCollector.tsx';
-import { loadJSON, TranslationGroup, Translations } from './translateUtils.tsx';
+import { updateTranslations } from './prepareTranslationsUtils.tsx';
+import { loadJSON, TranslationGroup } from './translateUtils.tsx';
 
 const root = process.cwd();
 
@@ -34,6 +33,12 @@ const argv = y
   )
   .array('locales')
   .alias('locales', 'locale')
+  .boolean('sort-by-hash')
+  .default('sort-by-hash', false)
+  .describe(
+    'sort-by-hash',
+    'Sort translation entries by hash key in output JSON. Applies to all entries (both existing and new).',
+  )
   .describe('h', 'Display usage message')
   .alias('h', 'help')
   .parseSync();
@@ -42,55 +47,6 @@ if (argv.help) {
   y.showHelp();
   process.exit(0);
 }
-
-type TranslationsWithMetadata = Partial<
-  Record<
-    PatternString,
-    | (SerializedTranslationData & { description?: string; status?: string })
-    | null
-  >
->;
-
-const updateTranslations = (
-  phrases: HashToLeaf,
-  translations: Translations,
-) => {
-  const hashes = new Set(Object.keys(phrases));
-  const translatedHashes = new Set(Object.keys(translations));
-  const newHashes = [...hashes].filter((hash) => !translatedHashes.has(hash));
-  const removedHashes = [...translatedHashes].filter(
-    (hash) => !hashes.has(hash),
-  );
-
-  const updatedTranslations: TranslationsWithMetadata = { ...translations };
-  for (const hash of newHashes) {
-    if (!updatedTranslations[hash]) {
-      const phrase = phrases[hash];
-      if (phrase) {
-        updatedTranslations[hash] = {
-          description: phrase.desc,
-          status: 'new',
-          tokens: [],
-          translations: [
-            {
-              translation: phrase.text,
-              variations: {},
-            },
-          ],
-          types: [],
-        };
-      }
-    }
-  }
-
-  for (const hash of removedHashes) {
-    if (updatedTranslations[hash]) {
-      delete updatedTranslations[hash];
-    }
-  }
-
-  return updatedTranslations;
-};
 
 const outputDirectory = join(root, argv['output-dir']);
 const files = globSync(join(outputDirectory, '*.json'));
@@ -122,7 +78,11 @@ for (const locale of locales) {
       {
         'fb-locale': locale,
         ...props,
-        translations: updateTranslations(phrases, translations),
+        translations: updateTranslations(
+          phrases,
+          translations,
+          argv['sort-by-hash'],
+        ),
       } satisfies TranslationGroup,
       null,
       2,

--- a/packages/babel-plugin-fbtee/src/bin/prepareTranslationsUtils.tsx
+++ b/packages/babel-plugin-fbtee/src/bin/prepareTranslationsUtils.tsx
@@ -1,0 +1,62 @@
+import type { SerializedTranslationData } from '../translate/TranslationData.tsx';
+import type { PatternString } from '../Types.ts';
+import type { HashToLeaf } from './FbtCollector.tsx';
+import type { Translations } from './translateUtils.tsx';
+
+export type TranslationsWithMetadata = Partial<
+  Record<
+    PatternString,
+    | (SerializedTranslationData & { description?: string; status?: string })
+    | null
+  >
+>;
+
+export const updateTranslations = (
+  phrases: HashToLeaf,
+  translations: Translations,
+  sortByHash = false,
+): TranslationsWithMetadata => {
+  const hashes = new Set(Object.keys(phrases));
+  const translatedHashes = new Set(Object.keys(translations));
+  const newHashes = [...hashes].filter((hash) => !translatedHashes.has(hash));
+  const removedHashes = [...translatedHashes].filter(
+    (hash) => !hashes.has(hash),
+  );
+
+  const updatedTranslations: TranslationsWithMetadata = { ...translations };
+  for (const hash of newHashes) {
+    if (!updatedTranslations[hash]) {
+      const phrase = phrases[hash];
+      if (phrase) {
+        updatedTranslations[hash] = {
+          description: phrase.desc,
+          status: 'new',
+          tokens: [],
+          translations: [
+            {
+              translation: phrase.text,
+              variations: {},
+            },
+          ],
+          types: [],
+        };
+      }
+    }
+  }
+
+  for (const hash of removedHashes) {
+    if (updatedTranslations[hash]) {
+      delete updatedTranslations[hash];
+    }
+  }
+
+  if (sortByHash) {
+    return Object.fromEntries(
+      Object.keys(updatedTranslations)
+        .sort()
+        .map((hash) => [hash, updatedTranslations[hash]]),
+    );
+  }
+
+  return updatedTranslations;
+};


### PR DESCRIPTION
fbtee prepare-translations - add optional argument `--sort-by-hash` that will result in deterministic order of translations in generated JSONs.

If this param is omitted - behaviour should be exactly the same as now.

Implements https://github.com/nkzw-tech/fbtee/issues/81